### PR TITLE
Fix Windows movie-info output

### DIFF
--- a/aebn_dl/downloader.py
+++ b/aebn_dl/downloader.py
@@ -179,6 +179,7 @@ class Downloader:
 
         print("Scenes and Segment Boundaries:")
         print("---------------------------------")
+        separator = "-" * 46
         for i, scene in enumerate(movie.scenes, 1):
             performers = ", ".join(scene.performers) if scene.performers else "N/A"
             print(f"Scene {i}")
@@ -186,7 +187,7 @@ class Downloader:
             print(f"End time:   {scene.end_timing}s")
             print(f"Segments:   {scene.start_segment} - {scene.end_segment}")
             print(f"Performers: {performers}")
-            print("──────────────────────────────────────────────")
+            print(separator)
 
     def _init_new_session(self, use_proxies: bool = True) -> None:
         """Init new curl_cffi session"""


### PR DESCRIPTION
## Why
The CLI was crashing on standard Windows consoles when printing the scene summary because it used Unicode box-drawing characters in the divider line. That broke `--info` mode even after the site metadata was successfully scraped.

## What changed
- Replaced the Unicode separator with an ASCII-safe alternative in the movie info output.
- Kept the existing output format otherwise unchanged so the CLI remains consistent across platforms.

## Verification
- Confirmed the real AEBN URL can be scraped successfully with `aebndl --info` once FFmpeg is installed and on PATH.
- Verified the info output prints without the Windows code-page encoding failure.